### PR TITLE
SDK-1412: Extra Data

### DIFF
--- a/examples/profile/tests/ProfileTest.php
+++ b/examples/profile/tests/ProfileTest.php
@@ -56,11 +56,12 @@ class ProfileTest extends PHPUnitTestCase
             new \DateTime('1980-01-01')
         );
 
+        $expiryDate = new \DateTime('+1 day');
         $extraData = (new SandboxExtraDataBuilder())
             ->withDataEntry(
                 (new SandboxAttributeIssuanceDetailsBuilder())
                     ->withDefinition('some-definition')
-                    ->withExpiryDate(new \DateTime('2020-01-01T00:00:00Z'))
+                    ->withExpiryDate($expiryDate)
                     ->withIssuanceToken('some-token')
                     ->build()
             )
@@ -121,7 +122,7 @@ class ProfileTest extends PHPUnitTestCase
         $attributeIssuanceDetails = $activityDetails->getExtraData()->getAttributeIssuanceDetails();
         $this->assertEquals(base64_encode('some-token'), $attributeIssuanceDetails->getToken());
         $this->assertEquals(
-            '2020-01-01T00:00:00+00:00',
+            $expiryDate->format(DATE_RFC3339),
             $attributeIssuanceDetails->getExpiryDate()->format(DATE_RFC3339)
         );
         $this->assertEquals(

--- a/src/Profile/Request/ExtraData/SandboxDataEntry.php
+++ b/src/Profile/Request/ExtraData/SandboxDataEntry.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Sandbox\Profile\Request\ExtraData;
+
+abstract class SandboxDataEntry implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var \JsonSerializable
+     */
+    private $value;
+
+    /**
+     * @param string $type
+     * @param \JsonSerializable $value
+     */
+    public function __construct(string $type, \JsonSerializable $value)
+    {
+        $this->type = $type;
+        $this->value = $value;
+    }
+
+    /**
+     * @return \stdClass
+     */
+    public function jsonSerialize(): \stdClass
+    {
+        return (object) [
+            'type' => $this->type,
+            'value' => $this->value,
+        ];
+    }
+}

--- a/src/Profile/Request/ExtraData/SandboxExtraData.php
+++ b/src/Profile/Request/ExtraData/SandboxExtraData.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Sandbox\Profile\Request\ExtraData;
+
+class SandboxExtraData implements \JsonSerializable
+{
+    /**
+     * @var SandboxDataEntry[]
+     */
+    private $dataEntries;
+
+    /**
+     * @param SandboxDataEntry[] $dataEntries
+     */
+    public function __construct(array $dataEntries)
+    {
+        $this->dataEntries = $dataEntries;
+    }
+
+    /**
+     * @return \stdClass
+     */
+    public function jsonSerialize(): \stdClass
+    {
+        return (object) [
+            'data_entry' => $this->dataEntries,
+        ];
+    }
+}

--- a/src/Profile/Request/ExtraData/SandboxExtraData.php
+++ b/src/Profile/Request/ExtraData/SandboxExtraData.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Yoti\Sandbox\Profile\Request\ExtraData;
 
+use Yoti\Util\Validation;
+
 class SandboxExtraData implements \JsonSerializable
 {
     /**
@@ -16,6 +18,7 @@ class SandboxExtraData implements \JsonSerializable
      */
     public function __construct(array $dataEntries)
     {
+        Validation::isArrayOfType($dataEntries, [SandboxDataEntry::class], 'dataEntries');
         $this->dataEntries = $dataEntries;
     }
 

--- a/src/Profile/Request/ExtraData/SandboxExtraDataBuilder.php
+++ b/src/Profile/Request/ExtraData/SandboxExtraDataBuilder.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Sandbox\Profile\Request\ExtraData;
+
+class SandboxExtraDataBuilder
+{
+    /**
+     * @var SandboxDataEntry[]
+     */
+    private $dataEntries = [];
+
+    /**
+     * @param SandboxDataEntry $dataEntry
+     *
+     * @return $this
+     */
+    public function withDataEntry($dataEntry): self
+    {
+        $this->dataEntries[] = $dataEntry;
+        return $this;
+    }
+
+    /**
+     * @return SandboxExtraData
+     */
+    public function build(): SandboxExtraData
+    {
+        return new SandboxExtraData($this->dataEntries);
+    }
+}

--- a/src/Profile/Request/ExtraData/SandboxExtraDataBuilder.php
+++ b/src/Profile/Request/ExtraData/SandboxExtraDataBuilder.php
@@ -16,7 +16,7 @@ class SandboxExtraDataBuilder
      *
      * @return $this
      */
-    public function withDataEntry($dataEntry): self
+    public function withDataEntry(SandboxDataEntry $dataEntry): self
     {
         $this->dataEntries[] = $dataEntry;
         return $this;

--- a/src/Profile/Request/ExtraData/ThirdParty/SandboxAttributeIssuanceDetails.php
+++ b/src/Profile/Request/ExtraData/ThirdParty/SandboxAttributeIssuanceDetails.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty;
+
+use Yoti\Sandbox\Profile\Request\ExtraData\SandboxDataEntry;
+
+class SandboxAttributeIssuanceDetails extends SandboxDataEntry
+{
+    private const TYPE = 'THIRD_PARTY_ATTRIBUTE';
+
+    /**
+     * @param SandboxAttributeIssuanceDetailsValue $value
+     */
+    public function __construct(SandboxAttributeIssuanceDetailsValue $value)
+    {
+        parent::__construct(self::TYPE, $value);
+    }
+}

--- a/src/Profile/Request/ExtraData/ThirdParty/SandboxAttributeIssuanceDetailsBuilder.php
+++ b/src/Profile/Request/ExtraData/ThirdParty/SandboxAttributeIssuanceDetailsBuilder.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty;
+
+use Yoti\Util\Validation;
+
+class SandboxAttributeIssuanceDetailsBuilder
+{
+    /**
+     * @var string
+     */
+    private $issuanceToken;
+
+    /**
+     * @var \DateTime
+     */
+    private $expiryDate;
+
+    /**
+     * @var SandboxDefinition[]
+     */
+    private $definitions;
+
+    /**
+     * @param string $issuanceToken
+     *
+     * @return $this
+     */
+    public function withIssuanceToken(string $issuanceToken): self
+    {
+        Validation::notEmptyString($issuanceToken, 'issuanceToken');
+        $this->issuanceToken = $issuanceToken;
+        return $this;
+    }
+
+    /**
+     * @param \DateTime $expiryDate
+     *
+     * @return $this
+     */
+    public function withExpiryDate(\DateTime $expiryDate): self
+    {
+        $this->expiryDate = $expiryDate;
+        return $this;
+    }
+
+    /**
+     * @param string $definition
+     *
+     * @return self
+     */
+    public function withDefinition(string $definition): self
+    {
+        Validation::notEmptyString($definition, 'definition');
+        $this->definitions[] = new SandboxDefinition($definition);
+        return $this;
+    }
+
+    /**
+     * @return SandboxAttributeIssuanceDetails
+     */
+    public function build(): SandboxAttributeIssuanceDetails
+    {
+        $value = new SandboxAttributeIssuanceDetailsValue(
+            $this->issuanceToken,
+            new SandboxIssuingAttributes($this->expiryDate, $this->definitions)
+        );
+        return new SandboxAttributeIssuanceDetails($value);
+    }
+}

--- a/src/Profile/Request/ExtraData/ThirdParty/SandboxAttributeIssuanceDetailsValue.php
+++ b/src/Profile/Request/ExtraData/ThirdParty/SandboxAttributeIssuanceDetailsValue.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty;
+
+class SandboxAttributeIssuanceDetailsValue implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $issuanceToken;
+
+    /**
+     * @var SandboxIssuingAttributes
+     */
+    private $issuingAttributes;
+
+    /**
+     * @param string $issuanceToken
+     * @param SandboxIssuingAttributes $issuingAttributes
+     */
+    public function __construct(string $issuanceToken, SandboxIssuingAttributes $issuingAttributes)
+    {
+        $this->issuanceToken = $issuanceToken;
+        $this->issuingAttributes = $issuingAttributes;
+    }
+
+    /**
+     * @return \stdClass
+     */
+    public function jsonSerialize(): \stdClass
+    {
+        return (object) [
+            'issuance_token' => $this->issuanceToken,
+            'issuing_attributes' => $this->issuingAttributes,
+        ];
+    }
+}

--- a/src/Profile/Request/ExtraData/ThirdParty/SandboxDefinition.php
+++ b/src/Profile/Request/ExtraData/ThirdParty/SandboxDefinition.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty;
+
+use Yoti\Util\Validation;
+
+class SandboxDefinition implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @param string $name
+     */
+    public function __construct(string $name)
+    {
+        Validation::notEmptyString($name, 'name');
+        $this->name = $name;
+    }
+
+    /**
+     * @return \stdClass
+     */
+    public function jsonSerialize(): \stdClass
+    {
+        return (object) [
+            'name' => $this->name,
+        ];
+    }
+}

--- a/src/Profile/Request/ExtraData/ThirdParty/SandboxIssuingAttributes.php
+++ b/src/Profile/Request/ExtraData/ThirdParty/SandboxIssuingAttributes.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty;
+
+use Yoti\Util\DateTime;
+use Yoti\Util\Validation;
+
+class SandboxIssuingAttributes implements \JsonSerializable
+{
+    /**
+     * @var \DateTime
+     */
+    private $expiryDate;
+
+    /**
+     * @var SandboxDefinition[]
+     */
+    private $definitions;
+
+    /**
+     * @param \DateTime $expiryDate
+     * @param SandboxDefinition[] $definitions
+     */
+    public function __construct(\DateTime $expiryDate, array $definitions)
+    {
+        $this->expiryDate = $expiryDate;
+
+        Validation::isArrayOfType($definitions, [SandboxDefinition::class], 'definitions');
+        $this->definitions = $definitions;
+    }
+
+    /**
+     * @return \stdClass
+     */
+    public function jsonSerialize(): \stdClass
+    {
+        return (object) [
+            'expiry_date' => $this->expiryDate->format(DateTime::RFC3339),
+            'definitions' => $this->definitions,
+        ];
+    }
+}

--- a/src/Profile/Request/ExtraData/ThirdParty/SandboxIssuingAttributes.php
+++ b/src/Profile/Request/ExtraData/ThirdParty/SandboxIssuingAttributes.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty;
 
-use Yoti\Util\DateTime;
 use Yoti\Util\Validation;
 
 class SandboxIssuingAttributes implements \JsonSerializable
@@ -37,7 +36,9 @@ class SandboxIssuingAttributes implements \JsonSerializable
     public function jsonSerialize(): \stdClass
     {
         return (object) [
-            'expiry_date' => $this->expiryDate->format(DateTime::RFC3339),
+            'expiry_date' => $this->expiryDate
+                ->setTimezone(new \DateTimeZone('UTC'))
+                ->format(\DateTime::RFC3339_EXTENDED),
             'definitions' => $this->definitions,
         ];
     }

--- a/src/Profile/Request/TokenRequest.php
+++ b/src/Profile/Request/TokenRequest.php
@@ -6,6 +6,8 @@ namespace Yoti\Sandbox\Profile\Request;
 
 use Yoti\Http\Payload;
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxAttribute;
+use Yoti\Sandbox\Profile\Request\ExtraData\SandboxExtraData;
+use Yoti\Util\Json;
 use Yoti\Util\Validation;
 
 class TokenRequest implements \JsonSerializable
@@ -21,15 +23,22 @@ class TokenRequest implements \JsonSerializable
     private $sandboxAttributes;
 
     /**
+     * @var SandboxExtraData|null
+     */
+    private $extraData;
+
+    /**
      * @param string|null $rememberMeId
      * @param SandboxAttribute[] $sandboxAttributes
      */
-    public function __construct(?string $rememberMeId, array $sandboxAttributes)
+    public function __construct(?string $rememberMeId, array $sandboxAttributes, ?SandboxExtraData $extraData = null)
     {
         $this->rememberMeId = $rememberMeId;
 
         Validation::isArrayOfType($sandboxAttributes, [ SandboxAttribute::class ], 'sandboxAttributes');
         $this->sandboxAttributes = $sandboxAttributes;
+
+        $this->extraData = $extraData;
     }
 
     /**
@@ -37,10 +46,11 @@ class TokenRequest implements \JsonSerializable
      */
     public function jsonSerialize(): array
     {
-        return [
+        return Json::withoutNullValues([
             'remember_me_id' => $this->rememberMeId,
             'profile_attributes' => $this->sandboxAttributes,
-        ];
+            'extra_data' => $this->extraData,
+        ]);
     }
 
     /**

--- a/src/Profile/Request/TokenRequestBuilder.php
+++ b/src/Profile/Request/TokenRequestBuilder.php
@@ -8,6 +8,7 @@ use Yoti\Profile\UserProfile;
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxAgeVerification;
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxAttribute;
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxDocumentDetails;
+use Yoti\Sandbox\Profile\Request\ExtraData\SandboxExtraData;
 
 class TokenRequestBuilder
 {
@@ -20,6 +21,11 @@ class TokenRequestBuilder
      * @var SandboxAttribute[]
      */
     private $sandboxAttributes = [];
+
+    /**
+     * @var SandboxExtraData|null
+     */
+    private $extraData;
 
     /**
      * @param string $value
@@ -264,6 +270,17 @@ class TokenRequestBuilder
     }
 
     /**
+     * @param SandboxExtraData $extraData
+     *
+     * @return self
+     */
+    public function setExtraData(SandboxExtraData $extraData): self
+    {
+        $this->extraData = $extraData;
+        return $this;
+    }
+
+    /**
      * @param string $name
      * @param string $value
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
@@ -314,6 +331,6 @@ class TokenRequestBuilder
      */
     public function build(): TokenRequest
     {
-        return new TokenRequest($this->rememberMeId, $this->sandboxAttributes);
+        return new TokenRequest($this->rememberMeId, $this->sandboxAttributes, $this->extraData);
     }
 }

--- a/tests/Profile/Request/ExtraData/SandboxDataEntryTest.php
+++ b/tests/Profile/Request/ExtraData/SandboxDataEntryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Sandbox\Test\Profile\Request\ExtraData\ThirdParty;
+
+use Yoti\Sandbox\Profile\Request\ExtraData\SandboxDataEntry;
+use Yoti\Sandbox\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\Sandbox\Profile\Request\ExtraData\SandboxDataEntry
+ */
+class SandboxDataEntryTest extends TestCase
+{
+    private const SOME_TYPE = 'some-type';
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::jsonSerialize
+     */
+    public function shouldSerializeToJson()
+    {
+        $valueMock = $this->createMock(\JsonSerializable::class);
+        $valueMock->method('jsonSerialize')->willReturn('some-value');
+
+        $sandboxDataEntry = $this->getMockBuilder(SandboxDataEntry::class)
+            ->setConstructorArgs([self::SOME_TYPE, $valueMock])
+            ->setMethodsExcept(['jsonSerialize'])
+            ->getMock();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'type' => self::SOME_TYPE,
+                'value' => $valueMock,
+            ]),
+            json_encode($sandboxDataEntry),
+        );
+    }
+}

--- a/tests/Profile/Request/ExtraData/SandboxDataEntryTest.php
+++ b/tests/Profile/Request/ExtraData/SandboxDataEntryTest.php
@@ -35,7 +35,7 @@ class SandboxDataEntryTest extends TestCase
                 'type' => self::SOME_TYPE,
                 'value' => $valueMock,
             ]),
-            json_encode($sandboxDataEntry),
+            json_encode($sandboxDataEntry)
         );
     }
 }

--- a/tests/Profile/Request/ExtraData/SandboxExtraDataBuilderTest.php
+++ b/tests/Profile/Request/ExtraData/SandboxExtraDataBuilderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Sandbox\Test\Profile\Request\ExtraData\ThirdParty;
+
+use Yoti\Sandbox\Profile\Request\ExtraData\SandboxDataEntry;
+use Yoti\Sandbox\Profile\Request\ExtraData\SandboxExtraDataBuilder;
+use Yoti\Sandbox\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\Sandbox\Profile\Request\ExtraData\SandboxExtraDataBuilder
+ */
+class SandboxExtraDataBuilderTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @covers ::build
+     * @covers ::withDataEntry
+     * @covers \Yoti\Sandbox\Profile\Request\ExtraData\SandboxExtraData::__construct
+     * @covers \Yoti\Sandbox\Profile\Request\ExtraData\SandboxExtraData::jsonSerialize
+     */
+    public function shouldBuildSandboxExtraData()
+    {
+        $dataEntryMock = $this->createMock(SandboxDataEntry::class);
+        $dataEntryMock->method('jsonSerialize')->willReturn((object) ['some' => 'data-entry']);
+
+        $extraData = (new SandboxExtraDataBuilder())
+            ->withDataEntry($dataEntryMock)
+            ->build();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'data_entry' => [$dataEntryMock]
+            ]),
+            json_encode($extraData),
+        );
+    }
+}

--- a/tests/Profile/Request/ExtraData/SandboxExtraDataBuilderTest.php
+++ b/tests/Profile/Request/ExtraData/SandboxExtraDataBuilderTest.php
@@ -34,7 +34,7 @@ class SandboxExtraDataBuilderTest extends TestCase
             json_encode([
                 'data_entry' => [$dataEntryMock]
             ]),
-            json_encode($extraData),
+            json_encode($extraData)
         );
     }
 }

--- a/tests/Profile/Request/ExtraData/ThirdParty/SandboxAttributeIssuanceDetailsBuilderTest.php
+++ b/tests/Profile/Request/ExtraData/ThirdParty/SandboxAttributeIssuanceDetailsBuilderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Sandbox\Test\Profile\Request\ExtraData\ThirdParty;
+
+use Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty\SandboxAttributeIssuanceDetailsBuilder;
+use Yoti\Sandbox\Test\TestCase;
+use Yoti\Util\DateTime;
+
+/**
+ * @coversDefaultClass \Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty\SandboxAttributeIssuanceDetailsBuilder
+ */
+class SandboxAttributeIssuanceDetailsBuilderTest extends TestCase
+{
+    private const SOME_TOKEN = 'some-token';
+    private const SOME_DEFINITION = 'some-definition';
+    private const SOME_DATE_STRING = '2020-01-02T01:02:03.123456Z';
+    private const TYPE_THIRD_PARTY_ATTRIBUTE = 'THIRD_PARTY_ATTRIBUTE';
+
+    /**
+     * @test
+     *
+     * @covers ::withDefinition
+     * @covers ::withExpiryDate
+     * @covers ::withIssuanceToken
+     * @covers ::build
+     * @covers \Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty\SandboxAttributeIssuanceDetails::__construct
+     * @covers \Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty\SandboxAttributeIssuanceDetails::jsonSerialize
+     */
+    public function shouldBuildSandboxAttributeIssuanceDetails()
+    {
+        $someDateTime = DateTime::stringToDateTime(self::SOME_DATE_STRING);
+
+        $sandboxAttributeIssuanceDetails = (new SandboxAttributeIssuanceDetailsBuilder())
+            ->withDefinition(self::SOME_DEFINITION)
+            ->withExpiryDate($someDateTime)
+            ->withIssuanceToken(self::SOME_TOKEN)
+            ->build();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'type' => self::TYPE_THIRD_PARTY_ATTRIBUTE,
+                'value' => [
+                    'issuance_token' => self::SOME_TOKEN,
+                    'issuing_attributes' => [
+                        'expiry_date' => $someDateTime->format(DateTime::RFC3339),
+                        'definitions' => [
+                            [
+                                'name' => self::SOME_DEFINITION,
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+            json_encode($sandboxAttributeIssuanceDetails),
+        );
+    }
+}

--- a/tests/Profile/Request/ExtraData/ThirdParty/SandboxAttributeIssuanceDetailsBuilderTest.php
+++ b/tests/Profile/Request/ExtraData/ThirdParty/SandboxAttributeIssuanceDetailsBuilderTest.php
@@ -44,7 +44,7 @@ class SandboxAttributeIssuanceDetailsBuilderTest extends TestCase
                 'value' => [
                     'issuance_token' => self::SOME_TOKEN,
                     'issuing_attributes' => [
-                        'expiry_date' => $someDateTime->format(DateTime::RFC3339),
+                        'expiry_date' => $someDateTime->format(\DateTime::RFC3339_EXTENDED),
                         'definitions' => [
                             [
                                 'name' => self::SOME_DEFINITION,

--- a/tests/Profile/Request/ExtraData/ThirdParty/SandboxAttributeIssuanceDetailsBuilderTest.php
+++ b/tests/Profile/Request/ExtraData/ThirdParty/SandboxAttributeIssuanceDetailsBuilderTest.php
@@ -53,7 +53,7 @@ class SandboxAttributeIssuanceDetailsBuilderTest extends TestCase
                     ],
                 ],
             ]),
-            json_encode($sandboxAttributeIssuanceDetails),
+            json_encode($sandboxAttributeIssuanceDetails)
         );
     }
 }

--- a/tests/Profile/Request/ExtraData/ThirdParty/SandboxAttributeIssuanceDetailsValueTest.php
+++ b/tests/Profile/Request/ExtraData/ThirdParty/SandboxAttributeIssuanceDetailsValueTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Sandbox\Test\Profile\Request\ExtraData\ThirdParty;
+
+use Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty\SandboxAttributeIssuanceDetailsValue;
+use Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty\SandboxIssuingAttributes;
+use Yoti\Sandbox\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty\SandboxAttributeIssuanceDetailsValue
+ */
+class SandboxAttributeIssuanceDetailsValueTest extends TestCase
+{
+    private const SOME_TOKEN = 'some-token';
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::jsonSerialize
+     */
+    public function shouldSerializeToJson()
+    {
+        $issuingAttributesMock = $this->createMock(SandboxIssuingAttributes::class);
+        $issuingAttributesMock
+            ->method('jsonSerialize')
+            ->willReturn((object) ['some' => 'issuing-attributes']);
+
+        $value = new SandboxAttributeIssuanceDetailsValue(self::SOME_TOKEN, $issuingAttributesMock);
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'issuance_token' => self::SOME_TOKEN,
+                'issuing_attributes' => $issuingAttributesMock,
+            ]),
+            json_encode($value)
+        );
+    }
+}

--- a/tests/Profile/Request/ExtraData/ThirdParty/SandboxDefinitionTest.php
+++ b/tests/Profile/Request/ExtraData/ThirdParty/SandboxDefinitionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Sandbox\Test\Profile\Request\ExtraData\ThirdParty;
+
+use Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty\SandboxDefinition;
+use Yoti\Sandbox\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty\SandboxDefinition
+ */
+class SandboxDefinitionTest extends TestCase
+{
+    private const SOME_NAME = 'some-name';
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::jsonSerialize
+     */
+    public function shouldSerializeToJson()
+    {
+        $definition = new SandboxDefinition(self::SOME_NAME);
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'name' => self::SOME_NAME,
+            ]),
+            json_encode($definition)
+        );
+    }
+}

--- a/tests/Profile/Request/ExtraData/ThirdParty/SandboxIssuingAttributesTest.php
+++ b/tests/Profile/Request/ExtraData/ThirdParty/SandboxIssuingAttributesTest.php
@@ -14,22 +14,22 @@ use Yoti\Util\DateTime;
  */
 class SandboxIssuingAttributesTest extends TestCase
 {
-    private const SOME_DATE_STRING = '2020-01-02T01:02:03.123456Z';
-
     /**
      * @test
      *
      * @covers ::__construct
      * @covers ::jsonSerialize
+     *
+     * @dataProvider expiryDateDataProvider
      */
-    public function shouldSerializeToJson()
+    public function shouldSerializeToJson($inputDate, $outputDate)
     {
         $definitionMock = $this->createMock(SandboxDefinition::class);
         $definitionMock
             ->method('jsonSerialize')
             ->willReturn((object) ['some' => 'definition']);
 
-        $someDateTime = DateTime::stringToDateTime(self::SOME_DATE_STRING);
+        $someDateTime = DateTime::stringToDateTime($inputDate);
 
         $sandboxIssuingAttributes = new SandboxIssuingAttributes(
             $someDateTime,
@@ -38,10 +38,22 @@ class SandboxIssuingAttributesTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(
             json_encode([
-                'expiry_date' => $someDateTime->format(DateTime::RFC3339),
+                'expiry_date' => $outputDate,
                 'definitions' => [$definitionMock],
             ]),
             json_encode($sandboxIssuingAttributes)
         );
+    }
+
+    /**
+     * Provides test expiry dates.
+     */
+    public function expiryDateDataProvider()
+    {
+        return [
+            ['2020-01-02T01:02:03.123456Z', '2020-01-02T01:02:03.123+00:00'],
+            ['2020-01-01T01:02:03.123+04:00', '2019-12-31T21:02:03.123+00:00'],
+            ['2020-01-02T01:02:03.123-02:00', '2020-01-02T03:02:03.123+00:00']
+        ];
     }
 }

--- a/tests/Profile/Request/ExtraData/ThirdParty/SandboxIssuingAttributesTest.php
+++ b/tests/Profile/Request/ExtraData/ThirdParty/SandboxIssuingAttributesTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Sandbox\Test\Profile\Request\ExtraData\ThirdParty;
+
+use Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty\SandboxDefinition;
+use Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty\SandboxIssuingAttributes;
+use Yoti\Sandbox\Test\TestCase;
+use Yoti\Util\DateTime;
+
+/**
+ * @coversDefaultClass \Yoti\Sandbox\Profile\Request\ExtraData\ThirdParty\SandboxIssuingAttributes
+ */
+class SandboxIssuingAttributesTest extends TestCase
+{
+    private const SOME_DATE_STRING = '2020-01-02T01:02:03.123456Z';
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::jsonSerialize
+     */
+    public function shouldSerializeToJson()
+    {
+        $definitionMock = $this->createMock(SandboxDefinition::class);
+        $definitionMock
+            ->method('jsonSerialize')
+            ->willReturn((object) ['some' => 'definition']);
+
+        $someDateTime = DateTime::stringToDateTime(self::SOME_DATE_STRING);
+
+        $sandboxIssuingAttributes = new SandboxIssuingAttributes(
+            $someDateTime,
+            [$definitionMock]
+        );
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'expiry_date' => $someDateTime->format(DateTime::RFC3339),
+                'definitions' => [$definitionMock],
+            ]),
+            json_encode($sandboxIssuingAttributes)
+        );
+    }
+}

--- a/tests/Profile/Request/TokenRequestBuilderTest.php
+++ b/tests/Profile/Request/TokenRequestBuilderTest.php
@@ -135,7 +135,6 @@ class TokenRequestBuilderTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(
             json_encode([
-                'remember_me_id' => null,
                 'profile_attributes' => [
                     [
                         'name' => $name,
@@ -173,7 +172,6 @@ class TokenRequestBuilderTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(
             json_encode([
-                'remember_me_id' => null,
                 'profile_attributes' => [
                     [
                         'name' => $name,
@@ -308,7 +306,6 @@ class TokenRequestBuilderTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(
             json_encode([
-                'remember_me_id' => null,
                 'profile_attributes' => [
                     [
                         'name' => 'selfie',
@@ -338,7 +335,6 @@ class TokenRequestBuilderTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(
             json_encode([
-                'remember_me_id' => null,
                 'profile_attributes' => [
                     [
                         'name' => 'selfie',
@@ -391,7 +387,6 @@ class TokenRequestBuilderTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(
             json_encode([
-                'remember_me_id' => null,
                 'profile_attributes' => [
                     [
                         'name' => 'document_details',
@@ -424,7 +419,6 @@ class TokenRequestBuilderTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(
             json_encode([
-                'remember_me_id' => null,
                 'profile_attributes' => [
                     [
                         'name' => 'document_details',
@@ -477,7 +471,6 @@ class TokenRequestBuilderTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(
             json_encode([
-                'remember_me_id' => null,
                 'profile_attributes' => [
                     [
                         'name' => 'document_details',

--- a/tests/Profile/Request/TokenRequestBuilderTest.php
+++ b/tests/Profile/Request/TokenRequestBuilderTest.php
@@ -7,6 +7,7 @@ namespace Yoti\Sandbox\Test\Profile\Request;
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxAgeVerification;
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor;
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxDocumentDetails;
+use Yoti\Sandbox\Profile\Request\ExtraData\SandboxExtraData;
 use Yoti\Sandbox\Profile\Request\TokenRequest;
 use Yoti\Sandbox\Profile\Request\TokenRequestBuilder;
 use Yoti\Sandbox\Test\TestCase;
@@ -91,7 +92,6 @@ class TokenRequestBuilderTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(
             json_encode([
-                'remember_me_id' => null,
                 'profile_attributes' => [
                     [
                         'name' => $name,
@@ -217,7 +217,6 @@ class TokenRequestBuilderTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(
             json_encode([
-                'remember_me_id' => null,
                 'profile_attributes' => [
                     [
                         'name' => $name,
@@ -263,7 +262,6 @@ class TokenRequestBuilderTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(
             json_encode([
-                'remember_me_id' => null,
                 'profile_attributes' => [
                     [
                         'name' => 'date_of_birth',
@@ -287,7 +285,6 @@ class TokenRequestBuilderTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(
             json_encode([
-                'remember_me_id' => null,
                 'profile_attributes' => [
                     [
                         'name' => 'selfie',
@@ -368,7 +365,6 @@ class TokenRequestBuilderTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(
             json_encode([
-                'remember_me_id' => null,
                 'profile_attributes' => [
                     [
                         'name' => 'document_details',
@@ -452,7 +448,6 @@ class TokenRequestBuilderTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(
             json_encode([
-                'remember_me_id' => null,
                 'profile_attributes' => [
                     [
                         'name' => 'document_details',
@@ -512,8 +507,26 @@ class TokenRequestBuilderTest extends TestCase
 
         $this->assertJsonStringEqualsJsonString(
             json_encode([
-                'remember_me_id' => null,
                 'profile_attributes' => [$someAgeVerification]
+            ]),
+            json_encode($tokenRequest)
+        );
+    }
+
+    /**
+     * @covers ::setExtraData
+     */
+    public function testSetExtraData()
+    {
+        $someExtraData  = $this->createMock(SandboxExtraData::class);
+        $someExtraData->method('jsonSerialize')->willReturn((object) ['some' => 'extra-data']);
+
+        $tokenRequest = $this->requestBuilder->setExtraData($someExtraData)->build();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'profile_attributes' => [],
+                'extra_data' => $someExtraData,
             ]),
             json_encode($tokenRequest)
         );


### PR DESCRIPTION
### Added
- Support for extra data
  - `TokenRequestBuilder::setExtraData(SandboxExtraData $extraData)`
  - `SandboxExtraDataBuilder` to build `SandboxExtraData`
    - `::withDataEntry(SandboxDataEntry $dataEntry)`
  - `SandboxAttributeIssuanceDetailsBuilder` to build `SandboxAttributeIssuanceDetails`
    - `SandboxAttributeIssuanceDetails` extends `SandboxDataEntry`
- Added extra data example
- Added Travis badge to README

### Changed
- `remember_me_id` is now excluded from payload when `null` _(non-breaking)_

> An integration test will also be added for this feature.