### PR TITLE
SDK-1523: Deprecate Optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "friendsofphp/php-cs-fixer": "^2.15",
     "brainmaestro/composer-git-hooks": "^2.8",
     "phpstan/phpstan-strict-rules": "^0.12.1",
-    "phpstan/extension-installer": "^1.0"
+    "phpstan/extension-installer": "^1.0",
+    "symfony/phpunit-bridge": "^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/examples/profile/tests/ProfileTest.php
+++ b/examples/profile/tests/ProfileTest.php
@@ -56,17 +56,17 @@ class ProfileTest extends PHPUnitTestCase
 
         $tokenRequest = (new TokenRequestBuilder())
             ->setRememberMeId('Some Remember Me ID')
-            ->setGivenNames('Some Given Names', false, $anchors)
-            ->setFamilyName('Some Family Name', false, $anchors)
-            ->setFullName('Some Full Name', false, $anchors)
-            ->setDateOfBirth(new \DateTime('1980-01-01'), false, $anchors)
-            ->setGender('Some Gender', false, $anchors)
+            ->setGivenNames('Some Given Names', $anchors)
+            ->setFamilyName('Some Family Name', $anchors)
+            ->setFullName('Some Full Name', $anchors)
+            ->setDateOfBirth(new \DateTime('1980-01-01'), $anchors)
+            ->setGender('Some Gender', $anchors)
             ->setPhoneNumber('Some Phone Number')
-            ->setNationality('Some Nationality', false, $anchors)
+            ->setNationality('Some Nationality', $anchors)
             ->setEmailAddress('some@email.address')
             ->setBase64Selfie(base64_encode('Some Selfie'))
             ->setAgeVerification($ageVerification)
-            ->setDocumentDetailsWithString('PASSPORT USA 1234abc', false, $anchors)
+            ->setDocumentDetailsWithString('PASSPORT USA 1234abc', $anchors)
             ->setStructuredPostalAddress(json_encode([
                 'building_number' => 1,
                 'address_line1' => 'Some Address',

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,4 +18,7 @@
     <logging>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
     </logging>
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>

--- a/src/Profile/Request/Attribute/SandboxAgeVerification.php
+++ b/src/Profile/Request/Attribute/SandboxAgeVerification.php
@@ -22,7 +22,6 @@ class SandboxAgeVerification extends SandboxAttribute
             UserProfile::ATTR_DATE_OF_BIRTH,
             $date->format('Y-m-d'),
             $derivation,
-            true,
             $anchors
         );
     }

--- a/src/Profile/Request/Attribute/SandboxAttribute.php
+++ b/src/Profile/Request/Attribute/SandboxAttribute.php
@@ -17,9 +17,6 @@ class SandboxAttribute implements \JsonSerializable
     /** @var string */
     protected $derivation;
 
-    /** @var bool */
-    protected $optional;
-
     /** @var \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] */
     protected $anchors;
 
@@ -27,20 +24,27 @@ class SandboxAttribute implements \JsonSerializable
      * @param string $name
      * @param string $value
      * @param string $derivation
-     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      */
     public function __construct(
         string $name,
         string $value,
         string $derivation = '',
-        bool $optional = false,
-        array $anchors = []
+        $anchors = []
     ) {
         $this->name = $name;
         $this->value = $value;
         $this->derivation = $derivation;
-        $this->optional = $optional;
+
+        $args = func_get_args();
+        if (isset($args[3]) && is_bool($args[3])) {
+            @trigger_error(
+                'Boolean argument 4 passed to ' . __METHOD__ . ' is deprecated in 1.1.0 ' .
+                'and will be removed in 2.0.0',
+                E_USER_DEPRECATED
+            );
+            $anchors = $args[4] ?? [];
+        }
 
         Validation::isArrayOfType($anchors, [\Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor::class], 'anchors');
         $this->anchors = $anchors;
@@ -55,7 +59,6 @@ class SandboxAttribute implements \JsonSerializable
             'name' => $this->name,
             'value' => $this->value,
             'derivation' => $this->derivation,
-            'optional' => $this->optional,
             'anchors' => $this->anchors,
         ];
     }

--- a/src/Profile/Request/TokenRequestBuilder.php
+++ b/src/Profile/Request/TokenRequestBuilder.php
@@ -32,273 +32,231 @@ class TokenRequestBuilder
 
     /**
      * @param string $value
-     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setFullName(string $value, bool $optional = false, array $anchors = []): self
+    public function setFullName(string $value, $anchors = []): self
     {
-        $this->addAttribute($this->createAttribute(
+        return $this->createAttribute(
             UserProfile::ATTR_FULL_NAME,
             $value,
-            '',
-            $optional,
-            $anchors
-        ));
-        return $this;
+            $this->getAnchors($anchors, func_get_args(), __METHOD__)
+        );
     }
 
     /**
      * @param string $value
-     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setFamilyName(string $value, bool $optional = false, array $anchors = []): self
+    public function setFamilyName(string $value, $anchors = []): self
     {
-        $this->addAttribute($this->createAttribute(
+        return $this->createAttribute(
             UserProfile::ATTR_FAMILY_NAME,
             $value,
-            '',
-            $optional,
-            $anchors
-        ));
-        return $this;
+            $this->getAnchors($anchors, func_get_args(), __METHOD__)
+        );
     }
 
     /**
      * @param string $value
-     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setGivenNames(string $value, bool $optional = false, array $anchors = []): self
+    public function setGivenNames(string $value, $anchors = []): self
     {
-        $this->addAttribute($this->createAttribute(
+        return $this->createAttribute(
             UserProfile::ATTR_GIVEN_NAMES,
             $value,
-            '',
-            $optional,
-            $anchors
-        ));
-        return $this;
+            $this->getAnchors($anchors, func_get_args(), __METHOD__)
+        );
     }
 
     /**
      * @param \DateTime $dateTime
-     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setDateOfBirth(\DateTime $dateTime, bool $optional = false, array $anchors = []): self
+    public function setDateOfBirth(\DateTime $dateTime, $anchors = []): self
     {
-        $this->addAttribute($this->createAttribute(
+        return $this->createAttribute(
             UserProfile::ATTR_DATE_OF_BIRTH,
             $dateTime->format('Y-m-d'),
-            '',
-            $optional,
-            $anchors
-        ));
-        return $this;
+            $this->getAnchors($anchors, func_get_args(), __METHOD__)
+        );
     }
 
     /**
      * @param string $value
-     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setGender(string $value, bool $optional = false, array $anchors = []): self
+    public function setGender(string $value, $anchors = []): self
     {
-        $this->addAttribute($this->createAttribute(
+        return $this->createAttribute(
             UserProfile::ATTR_GENDER,
             $value,
-            '',
-            $optional,
-            $anchors
-        ));
-        return $this;
+            $this->getAnchors($anchors, func_get_args(), __METHOD__)
+        );
     }
 
     /**
      * @param string $value
-     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setNationality(string $value, bool $optional = false, array $anchors = []): self
+    public function setNationality(string $value, $anchors = []): self
     {
-        $this->addAttribute($this->createAttribute(
+        return $this->createAttribute(
             UserProfile::ATTR_NATIONALITY,
             $value,
-            '',
-            $optional,
-            $anchors
-        ));
-        return $this;
+            $this->getAnchors($anchors, func_get_args(), __METHOD__)
+        );
     }
 
     /**
      * @param string $value
-     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setPhoneNumber(string $value, bool $optional = false, array $anchors = []): self
+    public function setPhoneNumber(string $value, $anchors = []): self
     {
-        $this->addAttribute($this->createAttribute(
+        return $this->createAttribute(
             UserProfile::ATTR_PHONE_NUMBER,
             $value,
-            '',
-            $optional,
-            $anchors
-        ));
-        return $this;
+            $this->getAnchors($anchors, func_get_args(), __METHOD__)
+        );
     }
 
     /**
      * @param string $value
-     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setSelfie(string $value, bool $optional = false, array $anchors = []): self
+    public function setSelfie(string $value, $anchors = []): self
     {
-        $base64Selfie = base64_encode($value);
-        return $this->setBase64Selfie($base64Selfie, $optional, $anchors);
+        return $this->setBase64Selfie(
+            base64_encode($value),
+            $this->getAnchors($anchors, func_get_args(), __METHOD__)
+        );
     }
 
     /**
      * @param string $value
-     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setBase64Selfie(string $value, bool $optional = false, array $anchors = []): self
+    public function setBase64Selfie(string $value, $anchors = []): self
     {
-        $this->addAttribute($this->createAttribute(
+        return $this->createAttribute(
             UserProfile::ATTR_SELFIE,
             $value,
-            '',
-            $optional,
-            $anchors
-        ));
-        return $this;
+            $this->getAnchors($anchors, func_get_args(), __METHOD__)
+        );
     }
 
     /**
      * @param string $value
-     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setEmailAddress(string $value, bool $optional = false, array $anchors = []): self
+    public function setEmailAddress(string $value, $anchors = []): self
     {
-        $this->addAttribute($this->createAttribute(
+        return $this->createAttribute(
             UserProfile::ATTR_EMAIL_ADDRESS,
             $value,
-            '',
-            $optional,
-            $anchors
-        ));
-        return $this;
+            $this->getAnchors($anchors, func_get_args(), __METHOD__)
+        );
     }
 
     /**
      * @param string $value
-     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setPostalAddress(string $value, bool $optional = false, array $anchors = []): self
+    public function setPostalAddress(string $value, $anchors = []): self
     {
-        $this->addAttribute($this->createAttribute(
+        return $this->createAttribute(
             UserProfile::ATTR_POSTAL_ADDRESS,
             $value,
-            '',
-            $optional,
-            $anchors
-        ));
-        return $this;
+            $this->getAnchors($anchors, func_get_args(), __METHOD__)
+        );
     }
 
     /**
      * @param string $value
-     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setStructuredPostalAddress(string $value, bool $optional = false, array $anchors = []): self
+    public function setStructuredPostalAddress(string $value, $anchors = []): self
     {
-        $this->addAttribute($this->createAttribute(
+        return $this->createAttribute(
             UserProfile::ATTR_STRUCTURED_POSTAL_ADDRESS,
             $value,
-            '',
-            $optional,
-            $anchors
-        ));
-        return $this;
+            $this->getAnchors($anchors, func_get_args(), __METHOD__)
+        );
     }
 
     /**
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxDocumentDetails $documentDetails
-     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
     public function setDocumentDetails(
         SandboxDocumentDetails $documentDetails,
-        bool $optional = true,
-        array $anchors = []
+        $anchors = []
     ): self {
-        $this->addAttribute($this->createAttribute(
+        return $this->createAttribute(
             UserProfile::ATTR_DOCUMENT_DETAILS,
             $documentDetails->getValue(),
-            '',
-            $optional,
-            $anchors
-        ));
-        return $this;
+            $this->getAnchors($anchors, func_get_args(), __METHOD__)
+        );
     }
 
     /**
      * @param string $value
-     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setDocumentDetailsWithString(string $value, bool $optional = true, array $anchors = []): self
+    public function setDocumentDetailsWithString(string $value, $anchors = []): self
     {
-        $this->addAttribute($this->createAttribute(
+        return $this->createAttribute(
             UserProfile::ATTR_DOCUMENT_DETAILS,
             $value,
-            '',
-            $optional,
-            $anchors
-        ));
-        return $this;
+            $this->getAnchors($anchors, func_get_args(), __METHOD__)
+        );
     }
 
+    /**
+     * @param SandboxAgeVerification $ageVerification
+     *
+     * @return $this
+     */
     public function setAgeVerification(SandboxAgeVerification $ageVerification): self
     {
         $this->addAttribute($ageVerification);
         return $this;
     }
 
+    /**
+     * @param SandboxAttribute $attribute
+     *
+     * @return $this
+     */
     public function addAttribute(SandboxAttribute $attribute): self
     {
         $this->sandboxAttributes[] = $attribute;
@@ -308,22 +266,47 @@ class TokenRequestBuilder
     /**
      * @param string $name
      * @param string $value
-     * @param string $derivation
-     *  Empty value means there is no derivation for this attribute
-     * @param bool $optional
-     *  false value means this attribute is required
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
-     * @return SandboxAttribute
+     * @return $this
      */
     private function createAttribute(
         string $name,
         string $value,
-        string $derivation,
-        bool $optional,
         array $anchors
-    ): SandboxAttribute {
-        return new SandboxAttribute($name, $value, $derivation, $optional, $anchors);
+    ): self {
+        return $this->addAttribute(new SandboxAttribute($name, $value, '', $anchors));
+    }
+
+    /**
+     * Get the anchors from the provided arguments.
+     *
+     * This provides backward compatibility for implementations providing
+     * the optional parameter, which has now been removed.
+     *
+     * @param mixed $anchors
+     *   The parameter expected to be an array of anchors.
+     * @param array<mixed> $args
+     *   The builder method args.
+     * @param string $method
+     *   The builder method being called.
+     *
+     * @return \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[]
+     */
+    private function getAnchors($anchors, array $args, string $method): array
+    {
+        if (is_array($anchors)) {
+            return $anchors;
+        }
+
+        if (is_bool($args[1])) {
+            @trigger_error(
+                "Boolean argument 2 passed to {$method} is deprecated in 1.1.0 and will be removed in 2.0.0",
+                E_USER_DEPRECATED
+            );
+        }
+
+        return $args[2] ?? [];
     }
 
     /**

--- a/tests/Profile/Request/Attribute/SandboxAgeVerificationTest.php
+++ b/tests/Profile/Request/Attribute/SandboxAgeVerificationTest.php
@@ -41,7 +41,6 @@ class SandboxAgeVerificationTest extends TestCase
                 'name' => UserProfile::ATTR_DATE_OF_BIRTH,
                 'value' => self::SOME_TIMESTAMP_DATE_STRING,
                 'derivation' => self::SOME_DERIVATION,
-                'optional' => true,
                 'anchors' => [],
             ]),
             json_encode($this->ageVerification)
@@ -64,7 +63,6 @@ class SandboxAgeVerificationTest extends TestCase
                 'name' => UserProfile::ATTR_DATE_OF_BIRTH,
                 'value' => self::SOME_TIMESTAMP_DATE_STRING,
                 'derivation' => 'age_over:20',
-                'optional' => true,
                 'anchors' => [],
             ]),
             json_encode($ageOverVerification)
@@ -87,7 +85,6 @@ class SandboxAgeVerificationTest extends TestCase
                 'name' => UserProfile::ATTR_DATE_OF_BIRTH,
                 'value' => self::SOME_TIMESTAMP_DATE_STRING,
                 'derivation' => 'age_under:30',
-                'optional' => true,
                 'anchors' => [],
             ]),
             json_encode($ageUnderVerification)

--- a/tests/Profile/Request/Attribute/SandboxAttributeTest.php
+++ b/tests/Profile/Request/Attribute/SandboxAttributeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yoti\Sandbox\Test\Profile\Request\Attribute;
 
+use Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor;
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxAttribute;
 use Yoti\Sandbox\Test\TestCase;
 
@@ -16,17 +17,16 @@ class SandboxAttributeTest extends TestCase
     private const SOME_VALUE = 'some-value';
 
     /**
-     * @var SandboxAttribute
+     * @var SandboxAnchor
      */
-    public $attribute;
+    private $mockAnchor;
 
     public function setup(): void
     {
-        $this->attribute = new SandboxAttribute(
-            self::SOME_NAME,
-            self::SOME_VALUE,
-            ''
-        );
+        $this->mockAnchor = $this->createMock(SandboxAnchor::class);
+        $this->mockAnchor
+            ->method('jsonSerialize')
+            ->willReturn(['some' => 'anchor']);
     }
 
     /**
@@ -35,15 +35,105 @@ class SandboxAttributeTest extends TestCase
      */
     public function testJsonSerialize()
     {
+        $attribute = new SandboxAttribute(
+            self::SOME_NAME,
+            self::SOME_VALUE,
+            ''
+        );
+
         $this->assertJsonStringEqualsJsonString(
             json_encode([
                 'name' => self::SOME_NAME,
                 'value' => self::SOME_VALUE,
                 'derivation' => '',
-                'optional' => false,
                 'anchors' => [],
             ]),
-            json_encode($this->attribute)
+            json_encode($attribute)
+        );
+    }
+
+    /**
+     * @covers ::jsonSerialize
+     * @covers ::__construct
+     */
+    public function testJsonSerializeWithAnchor()
+    {
+        $attribute = new SandboxAttribute(
+            self::SOME_NAME,
+            self::SOME_VALUE,
+            '',
+            [$this->mockAnchor]
+        );
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'name' => self::SOME_NAME,
+                'value' => self::SOME_VALUE,
+                'derivation' => '',
+                'anchors' => [$this->mockAnchor],
+            ]),
+            json_encode($attribute)
+        );
+    }
+
+    /**
+     * @group legacy
+     *
+     * phpcs:disable
+     * @expectedDeprecation Boolean argument 4 passed to Yoti\Sandbox\Profile\Request\Attribute\SandboxAttribute::__construct is deprecated in 1.1.0 and will be removed in 2.0.0
+     * phpcs:enable
+     *
+     * @covers ::jsonSerialize
+     * @covers ::__construct
+     */
+    public function testJsonSerializeWithOptional()
+    {
+        $attribute = new SandboxAttribute(
+            self::SOME_NAME,
+            self::SOME_VALUE,
+            '',
+            true
+        );
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'name' => self::SOME_NAME,
+                'value' => self::SOME_VALUE,
+                'derivation' => '',
+                'anchors' => [],
+            ]),
+            json_encode($attribute)
+        );
+    }
+
+    /**
+     * @group legacy
+     *
+     * phpcs:disable
+     * @expectedDeprecation Boolean argument 4 passed to Yoti\Sandbox\Profile\Request\Attribute\SandboxAttribute::__construct is deprecated in 1.1.0 and will be removed in 2.0.0
+     * phpcs:enable
+     *
+     * @covers ::jsonSerialize
+     * @covers ::__construct
+     */
+    public function testJsonSerializeWithOptionalAndAnchor()
+    {
+        $attribute = new SandboxAttribute(
+            self::SOME_NAME,
+            self::SOME_VALUE,
+            '',
+            true,
+            [$this->mockAnchor]
+        );
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'name' => self::SOME_NAME,
+                'value' => self::SOME_VALUE,
+                'derivation' => '',
+                'anchors' => [$this->mockAnchor],
+            ]),
+            json_encode($attribute)
         );
     }
 }

--- a/tests/Profile/Request/TokenRequestTest.php
+++ b/tests/Profile/Request/TokenRequestTest.php
@@ -19,7 +19,6 @@ class TokenRequestTest extends TestCase
         'name' => 'some-name',
         'value' => 'some-value',
         'derivation' => '',
-        'optional' => false,
         'anchors' => [],
     ];
 


### PR DESCRIPTION
### Deprecated
- Boolean argument 4 passed to `Yoti\Sandbox\Profile\Request\Attribute\SandboxAttribute::__construct` is deprecated and should be removed before `2.0.0`
- Boolean argument 2 passed to `Yoti\Sandbox\Profile\Request\TokenRequestBuilder` set methods is deprecated and should be removed before `2.0.0`

### Added
- `symfony/phpunit-bridge` dev dependency to test deprecation errors

> Note: I used `phpcs:disable/phpcs:enable` to ignore long deprecation annotation - in a future release of `symfony/phpunit-bridge` we can set the expection in the test and break the expected message onto multiple lines.