### PR TITLE
chore: resolve disallowed Composer plugin in CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,5 +48,10 @@
     "hooks": {
         "pre-commit": "composer test && composer lint"
     }
+  },
+  "config": {
+    "allow-plugins": {
+      "phpstan/extension-installer": true
+    }
   }
 }


### PR DESCRIPTION
This allows the `phpstan/extension-installer` to run as a Composer plugin, which was previously causing CI to fail.